### PR TITLE
Change the build instruction to eliminate deprecated instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   - Luego en el `build.gradle` de tu proyecto (el que pertenece al módulo "app") agrega lo siguiente dentro de la sección `dependencies`: 
 
     ```
-    compile project(':one_pay_sdk_tbkqa')
+    implementation project(':one_pay_sdk_tbkqa')
     ```
 
     El nombre del proyecto depende del nombre del archivo que hayas importado (o el nombre que le hayas puesto manualmente al subproyecto al importarlo. No olvides los dos puntos antes del nombre del proyecto.


### PR DESCRIPTION
@leosoto The README file considers to add the 'compile' instruction in the build.gradle file.  But it's considered deprecated since Android Gradle 3.0 plugin, and it will be removed at the last of this year. 

If there is any doubt, see https://developer.android.com/studio/build/dependencies?utm_source=android-studio#dependency_configurations