### PR TITLE
Add QR Drawing to the SDK

### DIFF
--- a/onepay/build.gradle
+++ b/onepay/build.gradle
@@ -27,4 +27,6 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'com.google.zxing:core:3.3.0'
+    implementation('com.journeyapps:zxing-android-embedded:3.6.0') { transitive = false }
 }

--- a/onepay/src/main/java/cl/ionix/tbk_ewallet_sdk_android/ui/QROnepayView.java
+++ b/onepay/src/main/java/cl/ionix/tbk_ewallet_sdk_android/ui/QROnepayView.java
@@ -1,0 +1,68 @@
+package cl.ionix.tbk_ewallet_sdk_android.ui;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.graphics.Bitmap;
+import android.support.annotation.Nullable;
+import android.support.v7.widget.AppCompatImageView;
+import android.util.AttributeSet;
+import android.view.View;
+import com.google.zxing.BarcodeFormat;
+import com.google.zxing.WriterException;
+import com.journeyapps.barcodescanner.BarcodeEncoder;
+
+import cl.ionix.tbk_ewallet_sdk_android.R;
+
+public class QROnepayView extends AppCompatImageView {
+
+    private Context mContext;
+    private AttributeSet attrs;
+    private int styleAttr;
+    private String ott;
+
+    public QROnepayView(Context context) {
+        super(context);
+        this.mContext = context;
+        initView();
+    }
+
+    public QROnepayView(Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+        this.mContext = context;
+        this.attrs = attrs;
+        initView();
+    }
+
+    public QROnepayView(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs);
+        this.mContext = context;
+        this.attrs = attrs;
+        this.styleAttr = defStyleAttr;
+        initView();
+    }
+
+    private void initView() {
+        TypedArray arr = mContext.obtainStyledAttributes(attrs, R.styleable.QROnepayView,
+                styleAttr,0);
+        ott = arr.getString(R.styleable.QROnepayView_ott);
+        Bitmap qrBitmap = generateQR(ott);
+        setImageBitmap(qrBitmap);
+        arr.recycle();
+    }
+
+    private Bitmap generateQR(String ott) {
+        BarcodeEncoder barcodeEncoder = new BarcodeEncoder();
+        try {
+            Bitmap bitmap = barcodeEncoder.encodeBitmap("onepay=ott:" + ott, BarcodeFormat.QR_CODE, 400, 400);
+            return bitmap;
+        } catch (WriterException e) {
+            return null;
+        }
+    }
+
+    public void setOtt(String ott) {
+        this.ott = ott;
+        Bitmap qrBitmap = generateQR(ott);
+        setImageBitmap(qrBitmap);
+    }
+}

--- a/onepay/src/main/res/values/attrs.xml
+++ b/onepay/src/main/res/values/attrs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="QROnepayView">
+        <attr name="ott" format="string"/>
+    </declare-styleable>
+</resources>


### PR DESCRIPTION
When implementing [cortafilas](https://www.transbankdevelopers.cl/producto/onepay#onepay-como-cortafila) mode in an Android App, it's necessary to draw an specific QR based on the OTT retrieved from the Transaction.create backend method.

This PR adds QR drawing to the Android SDK.